### PR TITLE
Feat: calculate and submit appointment endTime based on type duration

### DIFF
--- a/src/app/components/event-list-component/event-list-component.component.html
+++ b/src/app/components/event-list-component/event-list-component.component.html
@@ -20,9 +20,17 @@
               Virtual: {{ appointment.isVirtual ? 'Yes' : 'No' }}<br>
               Email: {{ appointment.email }}<br>
               Phone: {{ appointment.phoneNumber }}<br>
+              <span *ngIf="isAdmin && appointment.createdByAdmin">Created by: {{ appointment.createdByAdmin }}</span>
               <button class="btn btn-sm btn-danger mt-2" (click)="deleteAppointment(+appointment.id!)">
                 Delete
               </button>
+              <button
+              *ngIf="canEditAppointment(appointment)"
+              class="btn btn-sm btn-primary mt-2 mx-2"
+              (click)="editAppointment(appointment)"
+              >
+              Edit Appointment
+            </button>
             </li>
           </ul>
         </div>
@@ -81,9 +89,18 @@
               Virtual: {{ appointment.isVirtual ? 'Yes' : 'No' }}<br>
               Email: {{ appointment.email }}<br>
               Phone: {{ appointment.phoneNumber }}<br>
+              createdByAdmin: {{ appointment.createdByAdmin }}<br>
+              <span *ngIf="isAdmin && appointment.createdByAdmin">Created by and Admin</span>
               <button class="btn btn-sm btn-danger mt-2" (click)="deleteAppointment(+appointment.id!)">
                 Delete
               </button>
+              <button
+              *ngIf="canEditAppointment(appointment)"
+              class="btn btn-sm btn-primary mt-2 mx-2"
+              (click)="editAppointment(appointment)"
+              >
+              Edit Appointment
+            </button>
             </li>
           </ul>
         </div>

--- a/src/app/components/forms/book-appointment-form/book-appointment-form.component.html
+++ b/src/app/components/forms/book-appointment-form/book-appointment-form.component.html
@@ -58,7 +58,27 @@
               </mat-error>
             </mat-form-field>
           </div>
-          <div class="date-time-inputs mt-2 col offset-md-4">
+          <div *ngIf="isAdmin" class="date-time-inputs mt-2 col offset-md-4">
+            <div class="col">
+              <mat-form-field>
+                <mat-label>Select a date</mat-label>
+                <input matInput formControlName="date" [matDatepicker]="datepicker" [min]="_todaysDate"/>
+                <mat-datepicker-toggle matIconSuffix [for]="datepicker"></mat-datepicker-toggle>
+                <mat-datepicker #datepicker></mat-datepicker>
+                <mat-error *ngIf="appointmentForm.controls.date?.hasError('required')">This field is required</mat-error>
+              </mat-form-field>
+            </div>
+            <div class="col">
+              <mat-form-field>
+                <mat-label>Select a time</mat-label>
+                <input matInput [matTimepicker]="timepicker" formControlName="time">
+                <mat-timepicker #timepicker/>
+                <mat-timepicker-toggle [for]="timepicker" matSuffix/>
+                <mat-error *ngIf="appointmentForm.controls.time?.hasError('required')">This field is required</mat-error>
+              </mat-form-field>
+            </div>
+          </div>
+          <div *ngIf="!isAdmin" class="date-time-inputs mt-2 col offset-md-4">
             <div class="col">
               <mat-form-field>
                 <mat-label>Select a date</mat-label>

--- a/src/app/interfaces/appointment.ts
+++ b/src/app/interfaces/appointment.ts
@@ -1,10 +1,14 @@
 export interface Appointment {
-  id?:number,
-  userId:string,
-  type:string,
-  name:string,
-  email:string,
-  phoneNumber:string,
-  date:Date,
-  isVirtual:boolean
+  id?:number;
+  userId:string;
+  type:string;
+  name:string;
+  email:string;
+  phoneNumber:string;
+  date:Date;
+  startTime: Date;
+  endTime: Date;
+  city?: string;
+  isVirtual:boolean;
+  createdByAdmin: boolean;
 }

--- a/src/app/interfaces/event.ts
+++ b/src/app/interfaces/event.ts
@@ -4,7 +4,9 @@ export interface Event {
   eventType: string;
   clientName?: string | null;
   startDate: Date;
+  startTime: Date;
   endDate: Date;
+  endTime: Date;
   streetAddress?: string | null;
   city?: string | null;
   state?: string | null;

--- a/src/app/pages/admin/events-management/events-management.component.ts
+++ b/src/app/pages/admin/events-management/events-management.component.ts
@@ -20,16 +20,6 @@ export class EventsManagementComponent {
   }
 
   openBookAppointmentForm() {
-    // if (buttonType == 'readingButton') {
-    //     this.selectedServiceType = "Reading";
-    // } else if (buttonType == 'cleansingButton') {
-    //     this.selectedServiceType = "Cleansing";
-    // } else if (buttonType == 'initiationButton') {
-    //     this.selectedServiceType = "Initiation";
-    // } else if (buttonType == 'workshopButton') {
-    //     this.selectedServiceType = "Workshop";
-    // }
-
     const dialogRef = this.dialog.open(AppointmentFormComponent, {
         minWidth: '500px',
         data: {},

--- a/src/app/services/conflict-check.service.spec.ts
+++ b/src/app/services/conflict-check.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConflictCheckService } from './conflict-check.service';
+
+describe('ConflictCheckService', () => {
+  let service: ConflictCheckService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConflictCheckService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/conflict-check.service.ts
+++ b/src/app/services/conflict-check.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { EventsApiService } from './apis/events-api.service';
+import { AppointmentApiService } from './apis/appointmentApi.service';
+import { take, firstValueFrom } from 'rxjs';
+
+interface ConflictItem {
+  start: Date;
+  type: string;
+  isVirtual: boolean;
+  location?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConflictCheckService {
+  // Duration lookup in minutes
+  private readonly durations: Record<string, number> = {
+    // Appointments
+    READING: 30,
+    CLEANSING: 45,
+    INITIATION: 60,
+    WORKSHOP: 90,
+    // Events
+    BEMBE: 120,
+    LECTURE: 90,
+    EGUNGUN: 60,
+    TRAINING: 120
+  };
+
+  constructor(private appointmentApi: AppointmentApiService, private eventApi: EventsApiService) {}
+
+  async checkForConflicts(startTime: Date, type: string, isVirtual: boolean, location?: string): Promise<boolean> {
+    const [appointments, events] = await Promise.all([
+      firstValueFrom(this.appointmentApi.getAllAppointments().pipe(take(1))),
+      firstValueFrom(this.eventApi.getAllEvents().pipe(take(1)))
+    ]);
+
+    const allItems: ConflictItem[] = [
+      ...(appointments ?? []).map(appt => ({
+        start: new Date(appt.date),
+        type: appt.type,
+        isVirtual: appt.isVirtual,
+        location: appt.city ?? undefined
+      })),
+      ...(events ?? []).map(evt => ({
+        start: new Date(evt.startDate),
+        type: evt.eventType,
+        isVirtual: evt.isVirtual,
+        location: evt.city ?? undefined
+      }))
+    ];
+
+    const duration = this.durations[type] || 0;
+    const buffer = this.getBufferMinutes(isVirtual, location);
+    const endTime = new Date(startTime.getTime() + duration * 60 * 1000);
+
+    return allItems.some(item => {
+      const otherDuration = this.durations[item.type] || 0;
+      const otherBuffer = this.getBufferMinutes(item.isVirtual, item.location);
+      const otherStart = new Date(item.start.getTime() - otherBuffer * 60 * 1000);
+      const otherEnd = new Date(item.start.getTime() + otherDuration * 60 * 1000 + otherBuffer * 60 * 1000);
+
+      return startTime < otherEnd && endTime > otherStart;
+    });
+  }
+
+  private getBufferMinutes(isVirtual: boolean, location?: string): number {
+    if (isVirtual) return 15;
+    if (location?.toLowerCase().includes('bremerton')) return 150; // 2.5 hrs
+    if (location?.toLowerCase().includes('seattle')) return 45;
+    return 0;
+  }
+}

--- a/src/app/utils/date-time.utils.ts
+++ b/src/app/utils/date-time.utils.ts
@@ -1,0 +1,10 @@
+export function combineDateAndTime(date: Date, time: Date): Date {
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    time.getHours(),
+    time.getMinutes(),
+    time.getSeconds()
+  );
+}


### PR DESCRIPTION
This update enhances the appointment-booking form and the event-creation forms by calculating item endTimes on the client side before submission. It ensures that the backend receives the expected start and end times based on the selected appointment/event type.

Changes Include:

- Added local maps of appointment and event type durations inside the onSubmit methods of the form components.
- Used combineDateAndTime to create a full start Date, then added the correct duration in minutes to calculate endTime.
- Included endTime in the Appointment and Event objects sent to the backend.

This supports the backend logic for overlap detection and scheduling conflict prevention.