### PR TITLE
feat: prevent deletion of past appointments and events in delete service

### DIFF
--- a/src/app/components/event-list-component/event-list-component.component.html
+++ b/src/app/components/event-list-component/event-list-component.component.html
@@ -21,16 +21,6 @@
               Email: {{ appointment.email }}<br>
               Phone: {{ appointment.phoneNumber }}<br>
               <span *ngIf="isAdmin && appointment.createdByAdmin">Created by: {{ appointment.createdByAdmin }}</span>
-              <button class="btn btn-sm btn-danger mt-2" (click)="deleteAppointment(+appointment.id!)">
-                Delete
-              </button>
-              <button
-              *ngIf="canEditAppointment(appointment)"
-              class="btn btn-sm btn-primary mt-2 mx-2"
-              (click)="editAppointment(appointment)"
-              >
-              Edit Appointment
-            </button>
             </li>
           </ul>
         </div>
@@ -53,14 +43,6 @@
               {{ event.startDate | date: 'shortTime' }}<br>
               Type: {{ event.eventType }}<br>
               Virtual: {{ event.isVirtual ? 'Yes' : 'No' }}<br>
-              <div>
-                <button *ngIf="isAdmin" class="btn btn-sm btn-primary mt-2 mx-3" (click)="openEditEventDialog(event)">
-                  Edit Event Details
-                </button>
-                <button class="btn btn-sm btn-danger mt-2" (click)="deleteEvent(+event.id!)">
-                  Delete
-                </button>
-              </div>
             </li>
           </ul>
         </div>

--- a/src/app/components/shared/calendar-view/calendar-view.component.html
+++ b/src/app/components/shared/calendar-view/calendar-view.component.html
@@ -13,7 +13,7 @@
         <!-- Header -->
         <div class="card-header d-flex justify-content-between align-items-center bg-primary text-white">
           <h5 class="mb-0">
-            {{ selectedEvent.extendedProps?.['appointmentId'] ? 'Appointment Details' : 'Event Details' }}
+            {{ selectedEventDetails?.extendedProps?.['appointmentId'] ? 'Appointment Details' : 'Event Details' }}
           </h5>
           <button type="button" class="btn-close btn-close-white" aria-label="Close" (click)="closeEventDetails()"></button>
         </div>
@@ -21,49 +21,49 @@
         <!-- Body -->
         <div class="card-body">
           <!-- Name -->
-          <p *ngIf="selectedEvent.extendedProps?.['appointmentName']">
-            <strong>Name:</strong> {{ selectedEvent.extendedProps?.['appointmentName'] }}
+          <p *ngIf="selectedEventDetails?.extendedProps?.['appointmentName']">
+            <strong>Name:</strong> {{ selectedEventDetails?.extendedProps?.['appointmentName'] }}
           </p>
-          <p *ngIf="selectedEvent.extendedProps?.['eventName']">
-            <strong>Name:</strong> {{ selectedEvent.extendedProps?.['eventName'] }}
+          <p *ngIf="selectedEventDetails?.extendedProps?.['eventName']">
+            <strong>Name:</strong> {{ selectedEventDetails?.extendedProps?.['eventName'] }}
           </p>
 
           <!-- Time -->
           <p>
             <strong>Time:</strong>
-            {{ selectedEvent.extendedProps?.['eventStart'] }}
-            <ng-container *ngIf="selectedEvent.extendedProps?.['eventEnd']">
-              - {{ selectedEvent.extendedProps?.['eventEnd'] }}
+            {{ selectedEventDetails?.extendedProps?.['eventStart'] }}
+            <ng-container *ngIf="selectedEventDetails?.extendedProps?.['eventEnd']">
+              - {{ selectedEventDetails?.extendedProps?.['eventEnd'] }}
             </ng-container>
           </p>
 
           <!-- Contact Info -->
-          <p *ngIf="selectedEvent.extendedProps?.['appointmentEmail']">
-            <strong>Email:</strong> {{ selectedEvent.extendedProps?.['appointmentEmail'] }}
+          <p *ngIf="selectedEventDetails?.extendedProps?.['appointmentEmail']">
+            <strong>Email:</strong> {{ selectedEventDetails?.extendedProps?.['appointmentEmail'] }}
           </p>
-          <p *ngIf="selectedEvent.extendedProps?.['appointmentPhone']">
-            <strong>Phone:</strong> {{ selectedEvent.extendedProps?.['appointmentPhone'] }}
+          <p *ngIf="selectedEventDetails?.extendedProps?.['appointmentPhone']">
+            <strong>Phone:</strong> {{ selectedEventDetails?.extendedProps?.['appointmentPhone'] }}
           </p>
 
           <!-- Description -->
           <p *ngIf="selectedEvent.extendedProps?.['eventDescription']">
-            <strong>Description:</strong> {{ selectedEvent.extendedProps?.['eventDescription'] }}
+            <strong>Description:</strong> {{ selectedEventDetails?.extendedProps?.['eventDescription'] }}
           </p>
 
           <!-- Virtual Field -->
-          <p *ngIf="selectedEvent.extendedProps?.['appointmentVirtual'] || selectedEvent.extendedProps?.['eventVirtual']">
+          <p *ngIf="selectedEventDetails?.extendedProps?.['appointmentVirtual'] || selectedEvent.extendedProps?.['eventVirtual']">
             <strong>Virtual:</strong> Yes
           </p>
 
           <!-- Address (non-virtual events only) -->
-          <ng-container *ngIf="!selectedEvent.extendedProps?.['appointmentId'] && !selectedEvent.extendedProps?.['eventVirtual']">
+          <ng-container *ngIf="!selectedEventDetails?.extendedProps?.['appointmentId'] && !selectedEvent.extendedProps?.['eventVirtual']">
             <p><strong>Address:</strong></p>
             <div class="mb-2">
-              <div>{{ selectedEvent.extendedProps?.['eventStreet'] }}</div>
+              <div>{{ selectedEventDetails?.extendedProps?.['eventStreet'] }}</div>
               <div>
-                {{ selectedEvent.extendedProps?.['eventCity'] }},
-                {{ selectedEvent.extendedProps?.['eventState'] }}
-                {{ selectedEvent.extendedProps?.['eventZip'] }}
+                {{ selectedEventDetails?.extendedProps?.['eventCity'] }},
+                {{ selectedEventDetails?.extendedProps?.['eventState'] }}
+                {{ selectedEventDetails?.extendedProps?.['eventZip'] }}
               </div>
             </div>
           </ng-container>
@@ -71,10 +71,10 @@
 
         <!-- Footer Actions -->
         <div class="card-footer">
-          <button *ngIf="isAdmin && selectedEvent.extendedProps?.['appointmentId']" class="btn btn-sm btn-danger me-2" (click)="deleteAppointment()">
+          <button *ngIf="isAdmin && selectedEventDetails?.extendedProps?.['appointmentId'] && isFuture(selectedEvent.start)" class="btn btn-sm btn-danger me-2" (click)="deleteAppointment()">
             Cancel Appointment
           </button>
-          <button *ngIf="isAdmin && selectedEvent.extendedProps?.['eventId']" class="btn btn-sm btn-danger" (click)="deleteEvent()">
+          <button *ngIf="isAdmin && selectedEventDetails?.extendedProps?.['eventId'] && isFuture(selectedEvent.start)" class="btn btn-sm btn-danger" (click)="deleteEvent()">
             Cancel Event
           </button>
         </div>

--- a/src/app/services/events.service.ts
+++ b/src/app/services/events.service.ts
@@ -39,6 +39,7 @@ export class EventsService {
         appointmentEmail: appointment.email,
         appointmentPhone: appointment.phoneNumber,
         appointmentDate: appointment.date,
+        appointmentStartTime: appointment.startTime,
         appointmentVirtual: appointment.isVirtual,
       },
     }));
@@ -56,6 +57,7 @@ export class EventsService {
         eventName: event.eventName,
         eventType: event.eventType,
         eventStart: event.startDate,
+        eventStartTime: event.startTime,
         eventEnd: event.endDate,
         eventDescription: event.description,
         eventVirtual: event.isVirtual,


### PR DESCRIPTION
This commit introduces logic to prevent deletion of past appointments and events through the DeleteEventService, and ensures that both past and future items are properly passed to the service from the CalendarViewComponent.