### PR TITLE
refactor(auth): inject AuthWrapperService and integrate with main.ts and AuthService

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -15,6 +15,7 @@
           "options": {
             "outputPath": "dist/khepra-site",
             "index": "src/index.html",
+            "main": "src/main.ts",
             "polyfills": [
               "zone.js"
             ],

--- a/src/app/components/forms/book-appointment-form/book-appointment-form.component.html
+++ b/src/app/components/forms/book-appointment-form/book-appointment-form.component.html
@@ -8,7 +8,7 @@
   </div>
   <mat-dialog-content align="center">
   <!-- TODO: Consolidate error messages -->
-    <form class="border border-top-0 mb-5 p-4" [formGroup]="appointmentForm" (ngSubmit)="onSubmit(bookServiceForm)" #bookServiceForm="ngForm">
+    <form class="border border-top-0 mb-5 p-4" [formGroup]="appointmentForm" (ngSubmit)="onSubmit()" #bookServiceForm="ngForm">
       <div class="row">
         <!-- Only visible to admins -->
         <div class="row w-100" *ngIf="isAdmin">

--- a/src/app/pages/user/account-settings/account-settings.component.spec.ts
+++ b/src/app/pages/user/account-settings/account-settings.component.spec.ts
@@ -3,12 +3,18 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { AuthService } from 'src/app/services/authentication/auth.service';
 import { AccountSettingsComponent } from './account-settings.component';
-
+import { AuthWrapperService } from 'src/app/services/authentication/auth-wrapper.service';
+import { GET_AUTH_TOKEN } from 'src/app/services/authentication/auth-wrapper.service';
 @Component({ selector: 'app-change-password', standalone: true, template: '' })
 class MockChangePasswordComponent {}
 
 @Component({ selector: 'app-delete-account', standalone: true, template: '' })
 class MockDeleteAccountComponent {}
+
+const mockAuthWrapperService = {
+  user$: of({ role: 'user' }),
+  getCurrentUser: jasmine.createSpy('getCurrentUser').and.returnValue(Promise.resolve({ uid: 'test-user' }))
+};
 
 describe('AccountSettingsComponent', () => {
   let component: AccountSettingsComponent;
@@ -22,6 +28,11 @@ describe('AccountSettingsComponent', () => {
         MockDeleteAccountComponent,
       ],
       providers: [
+        { provide: GET_AUTH_TOKEN, useValue: of('mock-token') },
+        {
+          provide: AuthWrapperService,
+          useValue: mockAuthWrapperService,
+        },
         {
           provide: AuthService,
           useValue: {

--- a/src/app/pages/user/account-settings/account-settings.component.ts
+++ b/src/app/pages/user/account-settings/account-settings.component.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
 import { take } from 'rxjs';
+import { ChangePasswordComponent } from 'src/app/components/authenticate/change-password/change-password.component';
+import { DeleteAccountComponent } from 'src/app/components/authenticate/delete-account/delete-account.component';
 import { AuthService } from 'src/app/services/authentication/auth.service';
 
 @Component({
   selector: 'app-account-settings',
+  imports: [ChangePasswordComponent, DeleteAccountComponent],
   templateUrl: './account-settings.component.html',
   styleUrl: './account-settings.component.css'
 })

--- a/src/app/services/authentication/auth-wrapper.service.spec.ts
+++ b/src/app/services/authentication/auth-wrapper.service.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-import { AuthWrapperService, GET_AUTH_TOKEN } from './auth-wrapper.service';
 import {
   Auth,
-  User,
-  AuthProvider,
   AuthCredential,
+  AuthProvider,
+  User,
 } from 'firebase/auth';
+import { AuthWrapperService, GET_AUTH_TOKEN } from './auth-wrapper.service';
 import { FirebaseAuthHelper } from './firebase-auth-helpers';
 
 describe('AuthWrapperService', () => {

--- a/src/app/services/authentication/auth.service.spec.ts
+++ b/src/app/services/authentication/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { Firestore } from '@angular/fire/firestore';
 import { Auth, GoogleAuthProvider, UserCredential, User, UserMetadata } from 'firebase/auth';
 import { of } from 'rxjs';
 import { AppUser } from 'src/app/interfaces/appUser';
+import { AuthWrapperService, GET_AUTH_TOKEN } from './auth-wrapper.service';
 
 const mockUser: User = {
   uid: 'test123',
@@ -41,8 +42,13 @@ describe('AuthService', () => {
     TestBed.configureTestingModule({
       providers: [
         AuthService,
-        { provide: 'auth', useValue: mockAuth },
-        { provide: Firestore, useValue: mockFirestore }
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: GET_AUTH_TOKEN, useValue: () => mockAuth }, // 👈 Provide GET_AUTH_TOKEN
+        {
+          provide: AuthWrapperService,
+          useFactory: (getAuthFn: () => Auth) => new AuthWrapperService(getAuthFn),
+          deps: [GET_AUTH_TOKEN]
+        }
       ]
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,11 @@ import { provideRouter } from '@angular/router';
 
 import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
 import { provideAuth, getAuth } from '@angular/fire/auth';
-import { provideFirestore, getFirestore } from '@angular/fire/firestore'; // 🔥 Add this
+import { provideFirestore, getFirestore } from '@angular/fire/firestore';
+
 import { firebaseConfig } from '../src/firebase-config';
-import { routes } from './app/app.routes'; 
+import { routes } from './app/app.routes';
+import { GET_AUTH_TOKEN } from './app/services/authentication/auth-wrapper.service';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -15,6 +17,8 @@ bootstrapApplication(AppComponent, {
     provideRouter(routes),
     provideFirebaseApp(() => initializeApp(firebaseConfig)),
     provideAuth(() => getAuth()),
-    provideFirestore(() => getFirestore())
+    provideFirestore(() => getFirestore()),
+
+    { provide: GET_AUTH_TOKEN, useValue: () => getAuth() },
   ],
 });


### PR DESCRIPTION
This commit refactors authentication service integration to support improved testability and clearer dependency injection by:

- Replacing direct use of Auth in AuthService with AuthWrapperService.
- Updating AuthService to call methods from AuthWrapperService and access getAuth() instead of injecting auth directly.
- Adding AuthWrapperService injection to main.ts via a custom GET_AUTH_TOKEN provider using getAuth() from Firebase.
- Resolving previous NullInjectorError issues in unit tests related to missing GET_AUTH_TOKEN provider.