### PR TITLE
fix: update checkEmailExists method and Firestore rules to allow email validation

### DIFF
--- a/src/app/components/shared/calendar-view/calendar-view.component.html
+++ b/src/app/components/shared/calendar-view/calendar-view.component.html
@@ -74,12 +74,12 @@
 
         <!-- Footer Actions -->
         <button
-          *ngIf="isAdmin && selectedEventDetails?.extendedProps?.['appointmentCreatedByAdmin'] && selectedEventDetails?.extendedProps?.['appointmentId']"
+          *ngIf="isAdmin && selectedEventDetails?.extendedProps?.['appointmentCreatedByAdmin'] && selectedEventDetails?.extendedProps?.['appointmentId'] && isFuture(selectedEventDetails?.extendedProps?.['appointment'].startTime)"
           class="btn btn-sm btn-primary mt-2 mx-3"
           (click)="editAppointment(selectedEventDetails?.extendedProps?.['appointment'])">
           Edit Appointment
         </button>
-        <button *ngIf="isAdmin && selectedEventDetails?.extendedProps?.['eventId']"
+        <button *ngIf="isAdmin && isFuture(selectedEvent?.start) && selectedEventDetails?.extendedProps?.['eventId']"
           class="btn btn-sm btn-primary mt-2 mx-3"
           (click)="openEditEventDialog(selectedEventDetails?.extendedProps?.['event'])">
           Edit Event


### PR DESCRIPTION
### Changes:
1. **Firestore Security Rules**:
   - Updated rules for the 'users' collection to allow authenticated users to **query** for email existence checks.
   - Enabled `get` and `list` operations for authenticated users to check if an email exists in the 'users' collection while maintaining security.
   - Kept the existing restrictions for reading and writing to the user's own document in the 'users' collection.

2. **checkEmailExists Method**:
   - Modified the `checkEmailExists` method in the `AuthService` to:
     - Query the 'users' collection for the provided email.
     - Return `false` if the email is associated with an admin account to prevent admins from booking appointments for themselves.
     - Return `true` if the email corresponds to a valid user (non-admin).

### Reason:
- These changes ensure that appointments can only be created for users with valid accounts and exclude admin emails from being used for booking appointments.
- The update to Firestore rules enables querying of the 'users' collection by authenticated users, which is necessary for the email validation process during appointment creation.

### Impact:
- The appointment form will now correctly check if an email is associated with a valid, non-admin user before allowing appointment creation.
- Admin users are excluded from booking appointments for themselves, ensuring proper user access control.
