### PR TITLE
feat(frontend): display admin-created appointments in user's appointment history

### DIFF
--- a/src/app/pages/user/appointment-history/appointment-history.component.spec.ts
+++ b/src/app/pages/user/appointment-history/appointment-history.component.spec.ts
@@ -1,11 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of, BehaviorSubject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { AppointmentHistoryComponent } from './appointment-history.component';
+import { BehaviorSubject, of } from 'rxjs';
+import { Appointment } from 'src/app/interfaces/appointment';
 import { AppointmentApiService } from 'src/app/services/apis/appointmentApi.service';
 import { AuthService } from 'src/app/services/authentication/auth.service';
 import { DeleteEventService } from 'src/app/services/delete-event.service';
-import { Appointment } from 'src/app/interfaces/appointment';
+import { AppointmentHistoryComponent } from './appointment-history.component';
 
 describe('AppointmentHistoryComponent', () => {
   let component: AppointmentHistoryComponent;

--- a/src/app/pages/user/appointment-history/appointment-history.component.ts
+++ b/src/app/pages/user/appointment-history/appointment-history.component.ts
@@ -30,11 +30,13 @@ export class AppointmentHistoryComponent implements OnInit {
   ngOnInit(): void {
     this.authService.user$.subscribe(user => {
       if (user?.uid) {
-        this.appointmentApiService.getAppointmentsByUserId(user.uid, 'upcoming').subscribe(appointments => {
+        // Fetch both user and admin-created upcoming appointments for the user
+        this.appointmentApiService.getAppointmentsByEmail(user.email, 'upcoming').subscribe(appointments => {
           this.upcomingAppointments = appointments;
           this.upcomingAppointments$.next(this.upcomingAppointments);
         });
 
+        // Fetch both user and admin-created past appointments for the user
         this.pastAppointments$ = this.appointmentApiService.getAppointmentsByUserId(user.uid, 'past');
       }
     });

--- a/src/app/services/apis/appointmentApi.service.ts
+++ b/src/app/services/apis/appointmentApi.service.ts
@@ -28,7 +28,6 @@ export class AppointmentApiService {
   return this.http.get<Appointment[]>('/api/appointments', { params });
 }
 
-
   // Get one appointment by its ID
   getAppointmentById(id: number): Observable<Appointment> {
     return this.http.get<Appointment>(`${this.baseUrl}/${id}`);
@@ -42,6 +41,15 @@ export class AppointmentApiService {
     return this.http.get<Appointment[]>(`/api/appointments`, { params });
   }
   
+  getAppointmentsByEmail(email: string, filter?: 'upcoming' | 'past'): Observable<Appointment[]> {
+    let params = new HttpParams().set('email', email);
+
+    if (filter) {
+      params = params.set('filter', filter);
+    }
+
+    return this.http.get<Appointment[]>(this.baseUrl, { params });
+  }
 
   // Create new appointment
   createAppointment(appointment: Appointment): Observable<Appointment> {


### PR DESCRIPTION
### Changes:
1. **Displaying Admin-Created Appointments**:
   - Updated the frontend to include **admin-created appointments** in addition to user-created appointments in the user's appointment history.

### Reason:
- This update ensures that **admin-created appointments** are visible in the user's appointment history, offering a complete view of the user’s appointments, regardless of who created them.
- Users and admins can now track **all appointments** (whether created by the user or an admin) in the history.

### Impact:
- Users will now see **all appointments** in their history, including those created by admins.
