### PR TITLE
fix: Redirects to home page after user logs out

### DIFF
--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,5 +1,4 @@
 // admin.guard.ts
-import { Injectable } from '@angular/core';
 import { CanActivateFn } from '@angular/router';
 import { inject } from '@angular/core';
 import { Auth } from '@angular/fire/auth';


### PR DESCRIPTION
Updated Authentication service so that when the user logs out they are also redirected to the home page.

Impact:

- Regular users won’t see "book" buttons on the service page, or see the access points to their Dashboard or Account Settings in the header after logging out
- Admins won’t see the access points to the Admin Panel or the Event Management in the header 